### PR TITLE
Option for adding variables with PropTypes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,3 +208,43 @@ class Example extends React.Component {
   }
 }
 ```
+
+- `declarePropTypeVariables` (boolean) - Adding declarations for variables of PropTypes. Defaults to `false`.
+
+```js
+module.exports = {
+  plugins: [['babel-plugin-typescript-to-proptypes', { declarePropTypeVariables: true }]],
+};
+```
+
+```js
+// Example.d.ts
+// Before
+import React from 'react';
+
+export interface Props {
+  name?: string;
+}
+
+// After
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export const Props = {
+  name: PropTypes.string
+};
+```
+
+```js
+// Example.js
+import React from 'react';
+import Props from './Example.d.ts';
+
+export class Example extends React.Component {
+  static propTypes = Props;
+
+  render() {
+    return <div />;
+  }
+}
+```

--- a/src/addToClass.ts
+++ b/src/addToClass.ts
@@ -16,7 +16,10 @@ function findStaticProperty(
   );
 }
 
-export default function addToClass(node: t.ClassDeclaration, state: ConvertState) {
+export default function addToClass(
+  node: t.ClassDeclaration,
+  state: ConvertState,
+) {
   if (!node.superTypeParameters || node.superTypeParameters.params.length <= 0) {
     return;
   }
@@ -31,7 +34,7 @@ export default function addToClass(node: t.ClassDeclaration, state: ConvertState
       }
     });
   }
-
+  
   const typeNames = extractGenericTypeNames(node.superTypeParameters.params[0]);
   const propTypesList = convertToPropTypes(
     state.componentTypes,
@@ -49,9 +52,10 @@ export default function addToClass(node: t.ClassDeclaration, state: ConvertState
   if (propTypes) {
     propTypes.value = mergePropTypes(propTypes.value, propTypesList, state);
   } else {
+    const isVariable = state.options.declarePropTypeVariables && typeNames.length === 1;
     const staticProperty = t.classProperty(
       t.identifier('propTypes'),
-      createPropTypesObject(propTypesList, state),
+      isVariable ? t.identifier(typeNames[0]) : createPropTypesObject(propTypesList, state),
     );
 
     // @ts-ignore

--- a/src/addToClass.ts
+++ b/src/addToClass.ts
@@ -52,7 +52,11 @@ export default function addToClass(
   if (propTypes) {
     propTypes.value = mergePropTypes(propTypes.value, propTypesList, state);
   } else {
-    const isVariable = state.options.declarePropTypeVariables && typeNames.length === 1;
+    const isVariable = (
+      state.options.declarePropTypeVariables &&
+      typeNames.length === 1 &&
+      typeof state.componentTypes[typeNames[0]] !== 'undefined'
+    );
     const staticProperty = t.classProperty(
       t.identifier('propTypes'),
       isVariable ? t.identifier(typeNames[0]) : createPropTypesObject(propTypesList, state),

--- a/src/addToFunctionOrVar.ts
+++ b/src/addToFunctionOrVar.ts
@@ -84,7 +84,11 @@ export default function addToFunctionOrVar(
   if (propTypes) {
     propTypes.right = mergePropTypes(propTypes.right, propTypesList, state);
   } else {
-    const isVariable = state.options.declarePropTypeVariables && typeNames.length === 1;
+    const isVariable = (
+      state.options.declarePropTypeVariables &&
+      typeNames.length === 1 &&
+      state.componentTypes[typeNames[0]]
+    );
 
     rootPath.insertAfter(
       t.expressionStatement(

--- a/src/addToFunctionOrVar.ts
+++ b/src/addToFunctionOrVar.ts
@@ -84,12 +84,14 @@ export default function addToFunctionOrVar(
   if (propTypes) {
     propTypes.right = mergePropTypes(propTypes.right, propTypesList, state);
   } else {
+    const isVariable = state.options.declarePropTypeVariables && typeNames.length === 1;
+
     rootPath.insertAfter(
       t.expressionStatement(
         t.assignmentExpression(
           '=',
           t.memberExpression(t.identifier(name), t.identifier('propTypes')),
-          createPropTypesObject(propTypesList, state),
+          isVariable ? t.identifier(typeNames[0]) : createPropTypesObject(propTypesList, state),
         ),
       ),
     );

--- a/src/addVariable.ts
+++ b/src/addVariable.ts
@@ -1,0 +1,34 @@
+import { types as t } from '@babel/core';
+import convertToPropTypes from './convertToPropTypes';
+import { createPropTypesObject } from './propTypes';
+import { Path, ConvertState } from './types';
+
+export default function addVariable(
+  path: Path<t.TSInterfaceDeclaration | t.TSTypeAliasDeclaration>,
+  name: string,
+  state: ConvertState,
+) {
+  const propTypesList = convertToPropTypes(state.componentTypes, [name], state, []);
+
+  if (propTypesList.length === 0) {
+    return;
+  }
+
+  const isExport = t.isExportDeclaration(path.parentPath);
+
+  const variableDeclaration = t.variableDeclaration(
+    'const',
+    [
+      t.variableDeclarator(
+        t.identifier(name),
+        createPropTypesObject(propTypesList, state),
+      ),
+    ],
+  );
+
+  path.insertAfter(
+    isExport ?
+      t.exportNamedDeclaration(variableDeclaration, []) :
+      variableDeclaration
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { types as t } from '@babel/core';
 // import ts from 'typescript';
 import addToClass from './addToClass';
 import addToFunctionOrVar from './addToFunctionOrVar';
+import addVariable from './addVariable';
 import extractTypeProperties from './extractTypeProperties';
 import upsertImport from './upsertImport';
 import { Path, PluginOptions, ConvertState } from './types';
@@ -202,19 +203,32 @@ export default declare((api: any, options: PluginOptions) => {
             },
 
             // `interface FooProps {}`
-            TSInterfaceDeclaration({ node }: Path<t.TSInterfaceDeclaration>) {
+            // @ts-ignore
+            TSInterfaceDeclaration(path: Path<t.TSInterfaceDeclaration>) {
+              const { node } = path;
+
               state.componentTypes[node.id.name] = extractTypeProperties(
                 node,
                 state.componentTypes,
               );
+
+              if (state.options.declarePropTypeVariables) {
+                addVariable(path, node.id.name, state);
+              }
             },
 
             // `type FooProps = {}`
-            TSTypeAliasDeclaration({ node }: Path<t.TSTypeAliasDeclaration>) {
+            TSTypeAliasDeclaration(path: Path<t.TSTypeAliasDeclaration>) {
+              const { node } = path;
+
               state.componentTypes[node.id.name] = extractTypeProperties(
                 node,
                 state.componentTypes,
               );
+
+              if (state.options.declarePropTypeVariables) {
+                addVariable(path, node.id.name, state);
+              }
             },
 
             // `const Foo: React.SFC<Props> = () => {};`

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,4 +27,5 @@ export type ConvertState = {
 export type PluginOptions = {
   customPropTypeSuffixes?: string[];
   forbidExtraProps?: boolean;
+  declarePropTypeVariables?: boolean;
 };

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -1,5 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`babel-plugin-typescript-to-proptypes supports adding variables for props 1`] = `
+"import _pt from 'prop-types';
+import React from 'react';
+interface AProps {
+  a: number;
+}
+const AProps = {
+  a: _pt.number.isRequired
+};
+interface BProps {
+  b: boolean;
+}
+const BProps = {
+  b: _pt.bool.isRequired
+};
+export interface Props extends AProps, BProps {
+  name: string;
+}
+export const Props = {
+  a: _pt.number.isRequired,
+  b: _pt.bool.isRequired,
+  name: _pt.string.isRequired
+};"
+`;
+
 exports[`babel-plugin-typescript-to-proptypes supports custom prop type suffixes 1`] = `
 "import React from 'react';
 import PropTypes from 'prop-types';
@@ -94,6 +119,31 @@ export default class AvoidsState extends React.Component<Props, State> {
 }"
 `;
 
+exports[`babel-plugin-typescript-to-proptypes transforms ./fixtures/avoids-state.ts with adding variables for props 1`] = `
+"import _pt from 'prop-types';
+import React from 'react';
+export interface Props {
+  name: string;
+}
+export const Props = {
+  name: _pt.string.isRequired
+};
+export interface State {
+  age: number;
+}
+export const State = {
+  age: _pt.number.isRequired
+};
+export default class AvoidsState extends React.Component<Props, State> {
+  static propTypes = Props;
+
+  render() {
+    return null;
+  }
+
+}"
+`;
+
 exports[`babel-plugin-typescript-to-proptypes transforms ./fixtures/class/custom-react-import-name.ts 1`] = `
 "import _pt from 'prop-types';
 import R from 'react';
@@ -122,6 +172,25 @@ export default class ClassCustomReactImportNamePure extends R.PureComponent<Prop
   static propTypes = {
     name: _pt.string.isRequired
   };
+
+  render() {
+    return null;
+  }
+
+}"
+`;
+
+exports[`babel-plugin-typescript-to-proptypes transforms ./fixtures/class/custom-react-import-name-pure.ts with adding variables for props 1`] = `
+"import _pt from 'prop-types';
+import R from 'react';
+interface Props {
+  name: string;
+}
+const Props = {
+  name: _pt.string.isRequired
+};
+export default class ClassCustomReactImportNamePure extends R.PureComponent<Props> {
+  static propTypes = Props;
 
   render() {
     return null;

--- a/tests/fixtures/special/add-variables.ts
+++ b/tests/fixtures/special/add-variables.ts
@@ -1,0 +1,13 @@
+import React from 'react';
+
+interface AProps {
+  a: number;
+}
+
+interface BProps {
+  b: boolean;
+}
+
+export interface Props extends AProps, BProps {
+  name: string;
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -178,4 +178,30 @@ describe('babel-plugin-typescript-to-proptypes', () => {
       ),
     ).toMatchSnapshot();
   });
+
+  glob
+    .sync('./fixtures/**/*.ts', { cwd: __dirname, dot: false, strict: true })
+    .slice(0, 2)
+    .forEach(filePath => {
+      if (filePath.includes('/special/')) {
+        return;
+      }
+
+      it(`transforms ${filePath} with adding variables for props`, () => {
+        expect(transform(path.join(__dirname, filePath), {}, { declarePropTypeVariables: true })).toMatchSnapshot();
+      });
+    });
+  
+  it('supports adding variables for props', () => {
+    expect(
+      transform(
+        path.join(__dirname, './fixtures/special/add-variables.ts'),
+        {},
+        {
+          declarePropTypeVariables: true,
+        },
+      ),
+    ).toMatchSnapshot();
+  });
+
 });


### PR DESCRIPTION
Hi!
We need this case for add our d.ts interfaces to JS as PropTypes. This is a temporary solution when moving our internal library from JS to TS. In the circumstances of using our library in both JS and TS projects.

- `addVariables` (boolean) - Adding variables for props. Defaults to `false`.

```js
module.exports = {
  plugins: [['babel-plugin-typescript-to-proptypes', { addVariables: true }]],
};
```

```js
// Example.d.ts
// Before
import React from 'react';

export interface Props {
  name?: string;
}

// After
import React from 'react';
import PropTypes from 'prop-types';

export const Props = {
  name: PropTypes.string
};
```

```js
// Example.js
import React from 'react';
import Props from './Example.d.ts';

export class Example extends React.Component {
  static propTypes = Props;

  render() {
    return <div />;
  }
}
```