### PR TITLE
Add leading comments to prop types

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,3 +407,43 @@ class Example extends React.Component {
   }
 }
 ```
+
+#### `leadingComments` (boolean)
+
+Copy comments from original source file for docgen purposes (default true).
+
+```tsx
+module.exports = {
+  plugins: [['babel-plugin-typescript-to-proptypes', { leadingComments: true }]],
+};
+```
+```tsx
+// Before
+import React from 'react';
+
+interface Props {
+  /** This name controls the fate of the whole universe */
+  name?: string;
+}
+
+class Example extends React.Component<Props> {
+  render() {
+    return <div />;
+  }
+}
+
+// After
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class Example extends React.Component {
+  static propTypes = {
+    /** This name controls the fate of the whole universe */
+    name: PropTypes.string,
+  };
+
+  render() {
+    return <div />;
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ module.exports = {
   plugins: [['babel-plugin-typescript-to-proptypes', { leadingComments: true }]],
 };
 ```
+
 ```tsx
 // Before
 import React from 'react';

--- a/src/convertBabelToPropTypes.ts
+++ b/src/convertBabelToPropTypes.ts
@@ -346,7 +346,7 @@ function convertListToProps(
     if (!property.typeAnnotation) {
       return false;
     }
-    
+
     const type = property.typeAnnotation.typeAnnotation;
     const propType = convert(type, state, depth);
     const { name } = property.key as t.Identifier;
@@ -359,7 +359,9 @@ function convertListToProps(
           property.optional || defaultProps.includes(name) || mustBeOptional(type),
         ),
       );
-      objProperty.leadingComments = getLeadingComments(property);
+      if (state.options.leadingComments) {
+        objProperty.leadingComments = getLeadingComments(property);
+      }
       propTypes.push(objProperty);
 
       if (name === 'children') {

--- a/src/convertBabelToPropTypes.ts
+++ b/src/convertBabelToPropTypes.ts
@@ -323,7 +323,7 @@ function convertArray(types: any[], state: ConvertState, depth: number): PropTyp
   return propTypes;
 }
 
-function getLeadingComments(property: TSPropertySignature): t.Comment[] {
+function getLeadingComments(property: t.TSPropertySignature): t.Comment[] {
   return Object.assign([], property.leadingComments);
 }
 

--- a/src/convertBabelToPropTypes.ts
+++ b/src/convertBabelToPropTypes.ts
@@ -6,7 +6,6 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 
 import { types as t } from '@babel/core';
-import { TSPropertySignature } from 'babel-types';
 import { convertSymbolFromSource } from './convertTSToPropTypes';
 import getTypeName from './getTypeName';
 import {

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ export default declare((api: any, options: PluginOptions, root: string) => {
           maxDepth: MAX_DEPTH,
           maxSize: MAX_SIZE,
           typeCheck: false,
+          leadingComments: true,
           ...options,
         },
         propTypes: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export interface PluginOptions {
   maxDepth?: number;
   maxSize?: number;
   typeCheck?: boolean | string;
+  leadingComments?: boolean;
 }
 
 export interface ConvertState {

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -1249,7 +1249,7 @@ export interface Props {
   objReturn: () => {};
   typeReturn?: () => string;
   args: (a: number, b: boolean) => null;
-  parens?: (() => void);
+  parens?: () => void;
   handler: React.ChangeEventHandler;
 }
 export default class TypeFunction extends React.Component<Props> {

--- a/tests/fixtures/type-function.ts
+++ b/tests/fixtures/type-function.ts
@@ -5,7 +5,7 @@ export interface Props {
   objReturn: () => {};
   typeReturn?: () => string;
   args: (a: number, b: boolean) => null;
-  parens?: (() => void);
+  parens?: () => void;
   handler: React.ChangeEventHandler;
 }
 


### PR DESCRIPTION
This change copies leading comments over for react-docgen or similar tools. Unsure how to create tests for this project, so just leaving that alone for now.