### PR TITLE
new: Add JSX Pragma and Preact support

### DIFF
--- a/src/jsx-pragma.ts
+++ b/src/jsx-pragma.ts
@@ -1,0 +1,71 @@
+import { JsxPragma } from './types';
+
+const JSXPragmaToFcNamesMap: Record<JsxPragma, string[]> = {
+  preact: ['ComponentFactory', 'FunctionComponent', 'FunctionalComponent'],
+  react: ['SFC', 'StatelessComponent', 'FC', 'FunctionComponent'],
+};
+
+const JSXPragmaToClassComponentNamesMap: Record<JsxPragma, string[]> = {
+  preact: ['Component', 'AnyComponent', 'ComponentClass', 'ComponentConstructor'],
+  react: ['Component', 'PureComponent'],
+};
+
+const JSXPragmaToFcDefaultImportNameMap: Record<JsxPragma, string> = {
+  preact: 'preact',
+  react: 'React',
+};
+
+const JSXPragmaToNodeTypesMap: Record<JsxPragma, string[]> = {
+  preact: ['VNode', 'Text', 'Element', 'JSX.Element', 'JSX.ElementClass'],
+  react: ['ReactText', 'ReactNode', 'ReactType', 'ElementType'],
+};
+
+const JSXPragmaToFunctionTypesMap: Record<JsxPragma, string[]> = {
+  preact: ['VNode', 'ComponentType', 'ComponentClass', 'ComponentConstructor', 'AnyComponent', 'ComponentType', 'Element', 'JSX.Element', 'JSX.ElementClass'],
+  react: ['ComponentType', 'ComponentClass', 'StatelessComponent', 'ElementType'],
+};
+
+const JSXPragmaToElementTypesMap: Record<JsxPragma, string[]> = {
+  preact: ['VNode', 'Element', 'JSX.Element', 'JSX.ElementClass'],
+  react: [
+    'ReactElement',
+    'ComponentElement',
+    'FunctionComponentElement',
+    'DOMElement',
+    'SFCElement',
+  ],
+};
+
+export function checkForUnsupportedPragma(pragma: string) {
+  if (!JSXPragmaToFcNamesMap[pragma as JsxPragma]) {
+    throw new Error(
+      `Unsupported JSX Pragma: ${pragma}, please use one of the following list: [${Object.keys(
+        JSXPragmaToFcNamesMap,
+      ).join(', ')}]`,
+    );
+  }
+}
+
+export function getFcNamesFromPragma(pragma: JsxPragma): string[] {
+  return JSXPragmaToFcNamesMap[pragma];
+}
+
+export function getClassComponentNamesFromPragma(pragma: JsxPragma): string[] {
+  return JSXPragmaToClassComponentNamesMap[pragma];
+}
+
+export function getDefaultImportNameFromPragma(pragma: JsxPragma): string {
+  return JSXPragmaToFcDefaultImportNameMap[pragma];
+}
+
+export function getNodeTypesFromPragma(pragma: JsxPragma): string[] {
+  return JSXPragmaToNodeTypesMap[pragma];
+}
+
+export function getFunctionTypesFromPragma(pragma: JsxPragma): string[] {
+  return JSXPragmaToFunctionTypesMap[pragma];
+}
+
+export function getElementTypesFromPragma(pragma: JsxPragma): string[] {
+  return JSXPragmaToElementTypesMap[pragma];
+}

--- a/src/propTypes.ts
+++ b/src/propTypes.ts
@@ -5,8 +5,17 @@ export function hasCustomPropTypeSuffix(name: string, suffixes?: string[]): bool
   return !!suffixes && suffixes.some((suffix) => name.endsWith(suffix));
 }
 
-export function isReactTypeMatch(name: string, type: string, reactImportedName: string): boolean {
-  return name === type || name === `React.${type}` || name === `${reactImportedName}.${type}`;
+export function isReactTypeMatch(
+  name: string,
+  type: string,
+  defaultImportName: string,
+  reactImportedName: string,
+): boolean {
+  return (
+    name === type ||
+    name === `${defaultImportName}.${type}` ||
+    name === `${reactImportedName}.${type}`
+  );
 }
 
 export function wrapIsRequired(propType: PropType, optional?: boolean | null): PropType {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,8 @@ export type PropTypeDeclaration = t.TSTypeReference | t.TSIntersectionType | t.T
 
 export type PropType = t.MemberExpression | t.CallExpression | t.Identifier | t.Literal;
 
+export type JsxPragma = 'react' | 'preact';
+
 export interface PluginOptions {
   comments?: boolean;
   customPropTypeSuffixes?: string[];
@@ -20,6 +22,7 @@ export interface PluginOptions {
   maxSize?: number;
   strict?: boolean;
   typeCheck?: boolean | string;
+  jsxPragma?: JsxPragma;
 }
 
 export interface ConvertState {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -307,6 +307,20 @@ describe('babel-plugin-typescript-to-proptypes', () => {
         ),
       ).toMatchSnapshot();
     });
+
+    it('emits unsupported pragma error if jsxPragma is not in the supported list', () => {
+      expect(
+        () => transform(
+          path.join(__dirname, './fixtures/special/ts-preset.ts'),
+          {
+            presets: ['@babel/preset-typescript'],
+          },
+          {
+            jsxPragma: 'something-else' as any,
+          },
+        ),
+      ).toThrow(/Unsupported JSX Pragma/u);
+    });
   });
 
   // describe('typeCheck', () => {


### PR DESCRIPTION
## Problem
```babel-plugin-typescript-to-proptypes``` does not support preact.

## Solution
Allow the plugin to be configured to use different "pragmas", so it can switch between React, Preact, or Inferno.

--

First of all, thanks for the awesome library, I have been using it in many projects, even professional ones, it helps to debug and speeds up development nicely.
One downside of this plugin is, however, that it does not support other JSX powered libraries, it is locked into React.
I have been using Preact for some of my projects and would love for this plugin to support it as well!
For that, I have forked your repository and made some changes, to allow the plugin to switch contexts between react and preact.

To use preact, a user can simply set up a "jsxPragma" config option to "preact". The plugin will then use preact references instead of React ones.
I had to do some small code refactoring for this to work. That is, extract constants and use some helper methods.
Please let me know what you think :)

(The code is still under development, and I am looking for feedback)