### PR TITLE
feat: allow to map unknown ref types to any via a config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,49 @@ class Example extends React.Component {
 }
 ```
 
+#### `mapUnknownReferenceTypesToAny` (boolean)
+
+By default unknown reference types are omitted from the generated prop types.
+Sometimes though it might be necessary to keep the prop in the generated prop types.
+In this case the prop type would be `any`.
+
+Defaults to `false`.
+
+```tsx
+module.exports = {
+  plugins: [['babel-plugin-typescript-to-proptypes', { mapUnknownReferenceTypesToAny: true }]],
+};
+```
+
+```tsx
+// Before
+import React from 'react';
+
+interface Props<T> {
+  as?: T;
+}
+
+class Example<T> extends React.Component<Props<T>> {
+  render() {
+    return <div />;
+  }
+}
+
+// After
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class Example extends React.Component {
+  static propTypes = {
+    as: PropTypes.any,
+  };
+
+  render() {
+    return <div />;
+  }
+}
+```
+
 #### `maxDepth` (number)
 
 Maximum depth to convert while handling recursive or deeply nested shapes. Defaults to `3`.

--- a/src/convertBabelToPropTypes.ts
+++ b/src/convertBabelToPropTypes.ts
@@ -191,8 +191,10 @@ function convert(type: any, state: ConvertState, depth: number): PropType | null
       return convertSymbolFromSource(state.filePath, name, state);
     }
 
-    // Nothing found, so just omit
-    return null;
+    // Nothing found. If explicitly requested, return a prop type with "any", otherwise omit the prop.
+    return state.options.mapUnknownReferenceTypesToAny
+      ? createMember(t.identifier('any'), propTypesImportedName)
+      : null;
 
     // [] -> PropTypes.arrayOf(), PropTypes.array
   } else if (t.isTSArrayType(type)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,7 @@ export default declare((api: any, options: PluginOptions, root: string) => {
           comments: false,
           customPropTypeSuffixes: [],
           forbidExtraProps: false,
+          mapUnknownReferenceTypesToAny: false,
           maxDepth: MAX_DEPTH,
           maxSize: MAX_SIZE,
           strict: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export interface PluginOptions {
   customPropTypeSuffixes?: string[];
   forbidExtraProps?: boolean;
   implicitChildren?: boolean;
+  mapUnknownReferenceTypesToAny?: boolean;
   maxDepth?: number;
   maxSize?: number;
   strict?: boolean;

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -220,6 +220,26 @@ export class ImplicitChildrenNoProps extends React.Component<PropsC> {
 }"
 `;
 
+exports[`babel-plugin-typescript-to-proptypes mapUnknownReferenceTypesToAny supports custom prop type suffixes 1`] = `
+"import _pt from 'prop-types';
+import React from 'react';
+export interface Props<T> {
+  as?: T;
+  others: Array<T>;
+}
+export default class UnknownReferenceTypeToAny<T> extends React.Component<Props<T>> {
+  static propTypes = {
+    as: _pt.any,
+    others: _pt.arrayOf(_pt.any).isRequired
+  };
+
+  render() {
+    return null;
+  }
+
+}"
+`;
+
 exports[`babel-plugin-typescript-to-proptypes maxDepth stops converting once max depth is met 1`] = `
 "import _pt from 'prop-types';
 import React from 'react';

--- a/tests/fixtures/special/map-unknown-reference-types-to-any.ts
+++ b/tests/fixtures/special/map-unknown-reference-types-to-any.ts
@@ -1,0 +1,13 @@
+import React from 'react';
+// @ts-ignore
+
+export interface Props<T> {
+  as?: T;
+  others: Array<T>;
+}
+
+export default class UnknownReferenceTypeToAny<T> extends React.Component<Props<T>> {
+  render() {
+    return null;
+  }
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -247,6 +247,20 @@ describe('babel-plugin-typescript-to-proptypes', () => {
     });
   });
 
+  describe('mapUnknownReferenceTypesToAny', () => {
+    it('supports custom prop type suffixes', () => {
+      expect(
+        transform(
+          path.join(__dirname, './fixtures/special/map-unknown-reference-types-to-any.ts'),
+          {},
+          {
+            mapUnknownReferenceTypesToAny: true,
+          },
+        ),
+      ).toMatchSnapshot();
+    });
+  });
+
   describe('maxDepth', () => {
     it('stops converting once max depth is met', () => {
       expect(


### PR DESCRIPTION
By default unknown reference types are omitted from the generated prop types (see https://github.com/milesj/babel-plugin-typescript-to-proptypes/issues/28).

Sometimes though it might be necessary to keep the prop in the generated prop types. In this case the prop type would be `any`.

I think it would help if users can choose to opt into this option. For that, I added a new `mapUnknownReferenceTypesToAny` option to control the behavior.